### PR TITLE
fix: add null checks for workload identity scenarios to prevent troubleshoot command failures

### DIFF
--- a/src/connectedk8s/azext_connectedk8s/_utils.py
+++ b/src/connectedk8s/azext_connectedk8s/_utils.py
@@ -185,9 +185,6 @@ def pull_helm_chart(
 ):
     chart_url = registry_path.split(":")[0]
     chart_version = registry_path.split(":")[1]
-    print(
-        f"Step: {get_utctimestring()}: Pulling HelmChart: {chart_url}, Version: {chart_version}"
-    )
 
     if new_path:
         # Version check for stable release train (chart_version will be in X.Y.Z format as opposed to X.Y.Z-NONSTABLE)
@@ -209,6 +206,10 @@ def pull_helm_chart(
         base_path = os.path.dirname(chart_url)
         image_name = os.path.basename(chart_url)
         chart_url = base_path + "/v2/" + image_name
+    
+    print(
+        f"Step: {get_utctimestring()}: Pulling HelmChart: {chart_url}, Version: {chart_version}"
+    )
 
     cmd_helm_chart_pull = [
         helm_client_location,

--- a/src/connectedk8s/azext_connectedk8s/custom.py
+++ b/src/connectedk8s/azext_connectedk8s/custom.py
@@ -4384,7 +4384,7 @@ def troubleshoot(
             )
 
         # saving signing key CR snapshot only if oidc issuer prfile is enabled
-        if connected_cluster.oidc_issuer_profile.enabled:
+        if connected_cluster.oidc_issuer_profile and connected_cluster.oidc_issuer_profile.enabled:
             storage_space_available = troubleshootutils.get_signingkey_cr_snapshot(
                 corev1_api_instance,
                 kubectl_client_location,
@@ -4396,8 +4396,12 @@ def troubleshoot(
 
         # saving all other workload identity related information if enabled
         if (
-            connected_cluster.oidc_issuer_profile.enabled
-            or connected_cluster.security_profile.workload_identity.enabled
+            connected_cluster.oidc_issuer_profile 
+            and connected_cluster.oidc_issuer_profile.enabled
+        ) or (
+            connected_cluster.security_profile 
+            and connected_cluster.security_profile.workload_identity 
+            and connected_cluster.security_profile.workload_identity.enabled
         ):
             # saving helm values of wiextension release
             storage_space_available = (

--- a/testing/pipeline/k8s-custom-pipelines.yml
+++ b/testing/pipeline/k8s-custom-pipelines.yml
@@ -44,6 +44,10 @@ stages:
     parameters:
       jobName: WorkloadIdentityTest
       path: ./test/configurations/WorkloadIdentity.Tests.ps1
+  - template: ./templates/run-test.yml
+    parameters:
+      jobName: TroubleshootTest
+      path: ./test/configurations/Troubleshoot.Tests.ps1
   - job: BuildPublishExtension
     pool:
       vmImage: 'ubuntu-20.04'

--- a/testing/test/configurations/Troubleshoot.Tests.ps1
+++ b/testing/test/configurations/Troubleshoot.Tests.ps1
@@ -1,0 +1,40 @@
+Describe 'Troubleshoot Scenario' {
+    BeforeAll {
+        . $PSScriptRoot/../helper/Constants.ps1
+    }
+
+    It 'Verify cluster onboarding process' {
+        az connectedk8s connect -n $ENVCONFIG.arcClusterName -g $ENVCONFIG.resourceGroup -l $ARC_LOCATION --no-wait
+        $? | Should -BeTrue
+        Start-Sleep -Seconds 10
+
+        # Loop and retry until the configuration installs
+        $n = 0
+        do 
+        {
+            $output = az connectedk8s show -n $ENVCONFIG.arcClusterName -g $ENVCONFIG.resourceGroup
+            $provisioningState = ($output | ConvertFrom-Json).provisioningState
+            Write-Host "Provisioning State: $provisioningState"
+            if ($provisioningState -eq $SUCCEEDED) {
+                break
+            }
+            Start-Sleep -Seconds 10
+            $n += 1
+        } while ($n -le $MAX_RETRY_ATTEMPTS)
+        $n | Should -BeLessOrEqual $MAX_RETRY_ATTEMPTS
+    }
+
+    It 'Verify troubleshoot command functionality' {
+        az connectedk8s troubleshoot -n $ENVCONFIG.arcClusterName -g $ENVCONFIG.resourceGroup
+        $? | Should -BeTrue
+    }
+
+    It "Delete the connected instance" {
+        az connectedk8s delete -n $ENVCONFIG.arcClusterName -g $ENVCONFIG.resourceGroup --force -y
+        $? | Should -BeTrue
+
+        # Configuration should be removed from the resource model
+        az connectedk8s show -n $ENVCONFIG.arcClusterName -g $ENVCONFIG.resourceGroup
+        $? | Should -BeFalse
+    }
+}


### PR DESCRIPTION
---
### Description
The troubleshoot cmd fails when workload identity is not enabled. There is null reference check missing for workload identity scenarios.

Errors screenshot:
<img width="1105" alt="image" src="https://github.com/user-attachments/assets/bb19d79e-7cf1-46b3-8054-c0aa246821b9">


This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
`az connectedk8s troubleshoot -n <clusterName> -g <resourceGroupName>`


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
