### PR TITLE
fix handling of private link at 2024-07 API

### DIFF
--- a/src/connectedk8s/azext_connectedk8s/custom.py
+++ b/src/connectedk8s/azext_connectedk8s/custom.py
@@ -1516,11 +1516,13 @@ def generate_request_payload(
         or arc_agent_profile is not None
     ):
         # Set additional parameters
-        private_link_state = None
+        kwargs = {}
         if enable_private_link is not None:
-            private_link_state = (
-                "Enabled" if enable_private_link is True else "Disabled"
+            kwargs["private_link_state"] = (
+                "Enabled" if enable_private_link else "Disabled"
             )
+        if private_link_scope_resource_id:
+            kwargs["private_link_scope_resource_id"] = private_link_scope_resource_id
 
         cc = ConnectedCluster(
             location=location,
@@ -1529,8 +1531,6 @@ def generate_request_payload(
             tags=tags,
             distribution=kubernetes_distro,
             infrastructure=kubernetes_infra,
-            private_link_scope_resource_id=private_link_scope_resource_id,
-            private_link_state=private_link_state,
             azure_hybrid_benefit=azure_hybrid_benefit,
             distribution_version=distribution_version,
             arc_agent_profile=arc_agent_profile,
@@ -1538,6 +1538,7 @@ def generate_request_payload(
             arc_agentry_configurations=arc_agentry_configurations,
             oidc_issuer_profile=oidc_profile,
             security_profile=security_profile,
+            **kwargs,
         )
 
     return cc


### PR DESCRIPTION
Fixing a breakage from #14 - apologies

`None` and `""` are not valid values for `private_link_state` and `private_link_scope_resource_id` respectively - but older API versions were tolerant of this

However - I think because we are doing a linked access check - newer API versions are not:
```
Http response error occured while making ARM request: (LinkedInvalidPropertyId) Property id '' at path 'properties.privateLinkScopeResourceId' is invalid. Expect fully qualified resource Id that start with '/subscriptions/{subscriptionId}'
 or '/providers/{resourceProviderNamespace}/'.
Code: LinkedInvalidPropertyId
Message: Property id '' at path 'properties.privateLinkScopeResourceId' is invalid. Expect fully qualified resource Id that start with '/subscriptions/{subscriptionId}' or '/providers/{resourceProviderNamespace}/'.
Summary: Unable to create connected cluster resource
```
---
Aside: the swagger definition could be improved to require a resource ID here by adding some annotations - currently it's a plain string, wibni to have:
```json
"format": "arm-id",
"x-ms-arm-id-details": {
  "allowedResources": [
    {
      "type": "Whatever/AppropriateType"
    }
  ]
}
```
Something to try and remember to add next time the API definition gets updated

---

Anyway here's a fix that only sets those values when they are not empty.