### PR TITLE
Tidying

### DIFF
--- a/src/connectedk8s/azext_connectedk8s/__init__.py
+++ b/src/connectedk8s/azext_connectedk8s/__init__.py
@@ -43,7 +43,7 @@ class Connectedk8sCommandsLoader(AzCommandsLoader):  # type: ignore[misc]
 COMMAND_LOADER_CLS = Connectedk8sCommandsLoader
 
 __all__ = [
-    "helps",
-    "Connectedk8sCommandsLoader",
     "COMMAND_LOADER_CLS",
+    "Connectedk8sCommandsLoader",
+    "helps",
 ]

--- a/src/connectedk8s/azext_connectedk8s/custom.py
+++ b/src/connectedk8s/azext_connectedk8s/custom.py
@@ -2289,10 +2289,6 @@ def update_connected_cluster(
     if disable_proxy:
         helm_content_values["global.isProxyEnabled"] = "False"
 
-    # Disable proxy if disable_proxy flag is set
-    if disable_proxy:
-        helm_content_values["global.isProxyEnabled"] = "False"
-
     # Set agent version in registry path
     if connected_cluster.agent_version is not None:
         agent_version = connected_cluster.agent_version  # type: ignore[unreachable]

--- a/src/connectedk8s/azext_connectedk8s/custom.py
+++ b/src/connectedk8s/azext_connectedk8s/custom.py
@@ -3267,7 +3267,7 @@ def disable_cluster_connect(
 def load_kubernetes_configuration(filename: str) -> dict[str, Any]:
     try:
         with open(filename) as stream:
-            k8s_config: dict[str, Any] = yaml.safe_load(stream)
+            k8s_config: dict[str, Any] = yaml.safe_load(stream) or {}
             return k8s_config
     except OSError as ex:
         if getattr(ex, "errno", 0) == errno.ENOENT:
@@ -3368,8 +3368,8 @@ def merge_kubernetes_configurations(
                 break
         except (KeyError, TypeError):
             continue
-    
-    if existing is None:
+
+    if not existing:
         existing = addition
     else:
         handle_merge(existing, addition, "clusters", replace)


### PR DESCRIPTION
@bavneetsingh16 I saw the 1.10.4 release and saw that this was mostly my bug, sorry about that.  Here's a slight variation on your fix that makes the type annotations true again and restores pipeline happiness.

I assume that the failing ruff and mypy pipelines currently don't block merges of pull requests?  I'd strongly suggest changing that.  Obvs we have just demonstrated that it is still possible to go wrong anyway, but I am quite sure that in the long run this would catch more bugs than it allows.