### PR TITLE
Skip CRDs with AKS addon manager label

### DIFF
--- a/src/connectedk8s/HISTORY.rst
+++ b/src/connectedk8s/HISTORY.rst
@@ -2,6 +2,10 @@
 
 Release History
 ===============
+1.10.13
++++++
+* Skip CRD deletion during Arc onboarding for CRDs managed by AKS addon manager (with label `addonmanager.kubernetes.io/mode: Reconcile`) to prevent extensionconfig from going into terminating state.
+
 1.10.12
 +++++
 * Removed deprecated '--app-id' and '--app-secret' RBAC parameters from the extension.

--- a/src/connectedk8s/setup.py
+++ b/src/connectedk8s/setup.py
@@ -13,7 +13,7 @@ from setuptools import find_packages, setup
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
 
-VERSION = "1.10.12"
+VERSION = "1.10.13"
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
az connectedk8s


- Before deleting each CRD, it now checks for the addonmanager.kubernetes.io/mode: Reconcile label
- If the label is present, the CRD is skipped to prevent extensionconfig from going into terminating state
- Also fixed a pre-existing bug where communicate() was called twice on a Popen object

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
