### PR TITLE
Add debug log for helm binary location

### DIFF
--- a/src/connectedk8s/azext_connectedk8s/custom.py
+++ b/src/connectedk8s/azext_connectedk8s/custom.py
@@ -304,6 +304,7 @@ def create_connectedk8s(
     try:
         kubectl_client_location = install_kubectl_client()
         helm_client_location = install_helm_client(cmd)
+        logger.debug("Using helm binary: %s", helm_client_location)
     except Exception as e:
         raise CLIInternalError(
             f"An exception has occured while trying to perform kubectl or helm install: {e}"


### PR DESCRIPTION
Added in custom.py immediately after helm_client_location = install_helm_client(cmd).

Why
Makes it easier to troubleshoot helm-related issues in the field. When a user runs az connectedk8s connect --debug, the log line shows exactly which helm binary is being used, whether it's the auto-downloaded binary in ~/.azure/helm/, a version placed there manually, or a custom path set via HELM_CLIENT_PATH.

Testing
Verified with --debug on AMD64 VM and ARM64 VM.
