### PR TITLE
connectedk8s: route config agent DP to staging extension DP in westus2 (Staging feature)

### DIFF
--- a/src/connectedk8s/HISTORY.rst
+++ b/src/connectedk8s/HISTORY.rst
@@ -2,6 +2,10 @@
 
 Release History
 ===============
+1.10.14
++++++++
+* Route the config agent data-plane endpoint to the regional staging extension DP (e.g. ``westus2stg``) during ``az connectedk8s connect`` when the subscription has the ``Microsoft.KubernetesConfiguration/Staging`` AFEC feature registered and the cluster is onboarded in ``westus2``.
+
 1.10.13
 +++++++
 * Propagate ``x-ms-correlation-request-id`` end-to-end for ``az connectedk8s proxy``: mint one uuid per session, stamp it on the outbound ARM call (echoed back by ARM) and thread it into every localhost call to arcProxy so the entire session (ARM → arcProxy → Relay → ConnectedProxyAgent) shares one id in logs and Geneva.

--- a/src/connectedk8s/azext_connectedk8s/_client_factory.py
+++ b/src/connectedk8s/azext_connectedk8s/_client_factory.py
@@ -163,6 +163,25 @@ def resource_providers_client(
     ).providers
     return providers
 
+
+def _feature_client_factory(cli_ctx: AzCli, subscription_id: str | None = None) -> Any:
+    access_token = os.getenv(consts.Azure_Access_Token_Variable)
+    if access_token is not None:
+        credential = AccessTokenCredential(access_token=access_token)
+        return get_mgmt_service_client(
+            cli_ctx,
+            ResourceType.MGMT_RESOURCE_FEATURES,
+            subscription_id=subscription_id,
+            credential=credential,
+        )
+    return get_mgmt_service_client(
+        cli_ctx, ResourceType.MGMT_RESOURCE_FEATURES, subscription_id=subscription_id
+    )
+
+
+def resource_features_client(cli_ctx: AzCli, subscription_id: str | None = None) -> Any:
+    return _feature_client_factory(cli_ctx, subscription_id).features
+
     # Alternate: This should also work
     # subscription_id = get_subscription_id(cli_ctx)
     # return get_mgmt_service_client(cli_ctx, ResourceType.MGMT_RESOURCE_RESOURCES,

--- a/src/connectedk8s/azext_connectedk8s/_constants.py
+++ b/src/connectedk8s/azext_connectedk8s/_constants.py
@@ -80,6 +80,16 @@ Custom_Locations_Provider_Namespace = "Microsoft.ExtendedLocation"
 Connected_Cluster_Provider_Namespace = "Microsoft.Kubernetes"
 Kubernetes_Configuration_Provider_Namespace = "Microsoft.KubernetesConfiguration"
 Hybrid_Compute_Provider_Namespace = "Microsoft.HybridCompute"
+
+# Staging config data-plane routing. When the subscription has the AFEC feature
+# "Microsoft.KubernetesConfiguration/Staging" registered and the cluster is being
+# onboarded in the supported staging region, the config agent's data-plane endpoint
+# is overridden to the regional staging DP (e.g. westus2 -> westus2stg.dp...), so
+# extension operations flow through the staging extension DP.
+Staging_Feature_Name = "Staging"
+Staging_Feature_Registered_State = "Registered"
+Staging_Supported_Location = "westus2"
+Staging_Config_Dp_Region_Suffix = "stg"
 Arc_Namespace = "azure-arc"
 Azure_PublicCloudName = "AZUREPUBLICCLOUD"
 Azure_USGovCloudName = "AZUREUSGOVERNMENTCLOUD"

--- a/src/connectedk8s/azext_connectedk8s/_utils.py
+++ b/src/connectedk8s/azext_connectedk8s/_utils.py
@@ -40,6 +40,7 @@ from packaging import version
 import azext_connectedk8s._constants as consts
 from azext_connectedk8s._client_factory import (
     cf_resource_groups,
+    resource_features_client,
     resource_providers_client,
 )
 
@@ -1311,6 +1312,7 @@ def helm_install_release(
     registry_path: str,
     aad_identity_principal_id: str | None,
     onboarding_timeout: str = consts.DEFAULT_MAX_ONBOARDING_TIMEOUT_HELMVALUE_SECONDS,
+    config_dp_endpoint_override: str | None = None,
 ) -> None:
     cmd_helm_install = [
         helm_client_location,
@@ -1391,6 +1393,18 @@ def helm_install_release(
     # Add overrides for AGC Scenario
     if cloud_name.lower() == "ussec" or cloud_name.lower() == "usnat":
         add_agc_endpoint_overrides(location, cloud_name, arm_metadata, cmd_helm_install)
+
+    # Override the config agent's data-plane endpoint (staging routing). Set before the DP
+    # helmValues content so a DP-provided value can still override it, consistent with the
+    # other config_dp_endpoint_override paths above.
+    if config_dp_endpoint_override:
+        cmd_helm_install.extend(
+            [
+                "--set",
+                "systemDefaultValues.azureArcAgents.config_dp_endpoint_override="
+                f"{config_dp_endpoint_override}",
+            ]
+        )
 
     # Add helmValues content response from DP
     cmd_helm_install = parse_helm_values(helm_content_values, cmd_helm=cmd_helm_install)
@@ -1625,6 +1639,32 @@ def is_guid(guid: str) -> bool:
         uuid.UUID(guid)
         return True
     except ValueError:
+        return False
+
+
+def is_staging_feature_registered(cli_ctx: AzCli, subscription_id: str) -> bool:
+    """Return True when the AFEC feature Microsoft.KubernetesConfiguration/Staging is
+    registered on the subscription. Used to route the config agent's data-plane traffic
+    to the regional staging extension DP. Any failure to read the feature (e.g. missing
+    permissions or a transient ARM error) is treated as "not registered" so onboarding
+    falls back to the production data-plane endpoint rather than failing.
+    """
+    try:
+        features = resource_features_client(cli_ctx, subscription_id)
+        feature = features.get(
+            consts.Kubernetes_Configuration_Provider_Namespace,
+            consts.Staging_Feature_Name,
+        )
+        state = getattr(getattr(feature, "properties", None), "state", None)
+        return state == consts.Staging_Feature_Registered_State
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug(
+            "Could not read the '%s/%s' feature registration; "
+            "defaulting to the production config data-plane endpoint. Error: %s",
+            consts.Kubernetes_Configuration_Provider_Namespace,
+            consts.Staging_Feature_Name,
+            str(e),
+        )
         return False
 
 

--- a/src/connectedk8s/azext_connectedk8s/custom.py
+++ b/src/connectedk8s/azext_connectedk8s/custom.py
@@ -291,6 +291,9 @@ def create_connectedk8s(
     config_dp_endpoint, release_train = get_config_dp_endpoint(
         cmd, location, values_file, arm_metadata
     )
+    config_dp_endpoint_override = get_staging_config_dp_endpoint_override(
+        cmd, location, subscription_id
+    )
 
     # Loading the kubeconfig file in kubernetes client configuration
     load_kube_config(kube_config, kube_context, skip_ssl_verification)
@@ -1069,6 +1072,7 @@ def create_connectedk8s(
         registry_path,
         aad_identity_principal_id,
         onboarding_timeout,
+        config_dp_endpoint_override,
     )
 
     # Long Running Operation for Agent State
@@ -1603,6 +1607,36 @@ def get_default_config_dp_endpoint(cmd: CLICommand, location: str) -> str:
         f"https://{location}.dp.kubernetesconfiguration.azure.{cloud_based_domain}"
     )
     return config_dp_endpoint
+
+
+def get_staging_config_dp_endpoint(cmd: CLICommand, location: str) -> str:
+    # Regional staging DP host, e.g. westus2 -> westus2stg.dp.kubernetesconfiguration.azure.<domain>
+    default_config_dp_endpoint = get_default_config_dp_endpoint(cmd, location)
+    return default_config_dp_endpoint.replace(
+        f"https://{location}.dp.",
+        f"https://{location}{consts.Staging_Config_Dp_Region_Suffix}.dp.",
+        1,
+    )
+
+
+def get_staging_config_dp_endpoint_override(
+    cmd: CLICommand, location: str, subscription_id: str
+) -> str | None:
+    # Only westus2 has a staging extension DP today, and only subscriptions with the
+    # Microsoft.KubernetesConfiguration/Staging AFEC feature registered should use it.
+    if not location or location.lower() != consts.Staging_Supported_Location:
+        return None
+    if not utils.is_staging_feature_registered(cmd.cli_ctx, subscription_id):
+        return None
+    staging_endpoint = get_staging_config_dp_endpoint(cmd, location)
+    logger.warning(
+        "Subscription has the '%s/%s' feature registered; routing the config agent "
+        "data-plane endpoint to the staging extension DP: %s",
+        consts.Kubernetes_Configuration_Provider_Namespace,
+        consts.Staging_Feature_Name,
+        staging_endpoint,
+    )
+    return staging_endpoint
 
 
 def get_config_dp_endpoint(

--- a/src/connectedk8s/azext_connectedk8s/tests/unittests/test_custom.py
+++ b/src/connectedk8s/azext_connectedk8s/tests/unittests/test_custom.py
@@ -86,3 +86,67 @@ def test_distro_invalid_metadata():
     node = create_node(provider_id="aws://node1", labels=None, annotations=None)
     api_response = V1NodeList(items=[node])
     assert get_kubernetes_distro(api_response) == "generic"
+
+
+class _FakeEndpoints:
+    def __init__(self, active_directory):
+        self.active_directory = active_directory
+
+
+class _FakeCloud:
+    def __init__(self, active_directory):
+        self.endpoints = _FakeEndpoints(active_directory)
+
+
+class _FakeCliCtx:
+    def __init__(self, active_directory="https://login.microsoftonline.com"):
+        self.cloud = _FakeCloud(active_directory)
+
+
+class _FakeCmd:
+    def __init__(self, active_directory="https://login.microsoftonline.com"):
+        self.cli_ctx = _FakeCliCtx(active_directory)
+
+
+def test_get_staging_config_dp_endpoint_public_cloud():
+    from azext_connectedk8s.custom import get_staging_config_dp_endpoint
+
+    cmd = _FakeCmd()
+    assert (
+        get_staging_config_dp_endpoint(cmd, "westus2")
+        == "https://westus2stg.dp.kubernetesconfiguration.azure.com"
+    )
+
+
+def test_get_staging_config_dp_endpoint_override_registered(monkeypatch):
+    from azext_connectedk8s import custom
+
+    monkeypatch.setattr(
+        custom.utils, "is_staging_feature_registered", lambda cli_ctx, sub: True
+    )
+    cmd = _FakeCmd()
+    assert (
+        custom.get_staging_config_dp_endpoint_override(cmd, "westus2", "sub-id")
+        == "https://westus2stg.dp.kubernetesconfiguration.azure.com"
+    )
+
+
+def test_get_staging_config_dp_endpoint_override_wrong_region(monkeypatch):
+    from azext_connectedk8s import custom
+
+    # Feature registered, but region is not the supported staging region -> no override.
+    monkeypatch.setattr(
+        custom.utils, "is_staging_feature_registered", lambda cli_ctx, sub: True
+    )
+    cmd = _FakeCmd()
+    assert custom.get_staging_config_dp_endpoint_override(cmd, "eastus", "sub-id") is None
+
+
+def test_get_staging_config_dp_endpoint_override_not_registered(monkeypatch):
+    from azext_connectedk8s import custom
+
+    monkeypatch.setattr(
+        custom.utils, "is_staging_feature_registered", lambda cli_ctx, sub: False
+    )
+    cmd = _FakeCmd()
+    assert custom.get_staging_config_dp_endpoint_override(cmd, "westus2", "sub-id") is None

--- a/src/connectedk8s/setup.py
+++ b/src/connectedk8s/setup.py
@@ -13,7 +13,7 @@ from setuptools import find_packages, setup
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
 
-VERSION = "1.10.13"
+VERSION = "1.10.14"
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
## Summary

During `az connectedk8s connect`, when a cluster is onboarded in **westus2** and the subscription has the AFEC feature **`Microsoft.KubernetesConfiguration/Staging`** registered, route the config agent's data-plane endpoint to the regional **staging** extension DP (`westus2` → `westus2stg.dp.kubernetesconfiguration.azure.com`).

This lets staging subscriptions exercise the staging extension DP without a separate onboarding flow.

## How it works

- New helper `is_staging_feature_registered(...)` reads the `Microsoft.KubernetesConfiguration/Staging` feature via `FeatureClient` — reliable because the CLI runs with the **user's ARM credentials** (mirrors the existing `check_provider_registrations` pattern). This is the same feature ARM already evaluates to route the control-plane PUT to the `westus2stg` RP endpoint.
- Reuses the **existing** `systemDefaultValues.azureArcAgents.config_dp_endpoint_override` helm value (same mechanism as the `arcConfigEndpoint` / AGC override paths). No new helm key, env var, or agent change.
- The override is emitted **before** the DP `GetHelmSettings` response is applied, so a future DP-provided value can still take precedence — consistent with today's ordering.
- Gated strictly to `location == westus2`; chart discovery (`GetHelmSettings`) stays on the production regional DP.

## Validation

- 4 new unit tests (registered / not-registered / wrong-region / endpoint transform) pass.
- **Live end-to-end**: onboarded an AKS cluster in westus2 on a staging-registered subscription. The deployed `azure-clusterconfig` configmap carries `DP_ENDPOINT_OVERRIDE=https://westus2stg.dp.kubernetesconfiguration.azure.com`, and the config-agent reaches the staging DP successfully (200s on `getPendingConfigs`).

## Dependency (must land for full staging health)

This CLI change routes **all** config-agent DP traffic to the staging stamp — including cluster **metadata sync**. The staging DP stamp (`westus2stg`, internal `Location=eastus2euap`) currently lacks the `ResourceSyncConfig` row for `(microsoft.kubernetes, eastus2euap) → metadatasync1`, so metadata sync returns `400 Eventhub not registered` and `connectivityStatus` stays `Connecting` until that DP-side registration is added. Extension operations themselves work. Tracking the DP EventHub registration separately.
