### PR TITLE
Pin ruff<0.16.0 to avoid breaking default rule changes

### DIFF
--- a/src/connectedk8s/setup.py
+++ b/src/connectedk8s/setup.py
@@ -59,7 +59,7 @@ setup(
     extras_require={
         "linting": [
             "mypy>=1.13.0",
-            "ruff>=0.7.2",
+            "ruff>=0.7.2,<0.16.0",
             "types-jmespath>=1.0.2",
             "types-psutil>=6.1.0",
             "types-pyyaml>=6.0.12",


### PR DESCRIPTION
## Problem
ruff 0.16.0 introduced new default lint rules and markdown formatting that cause CI failures across the entire connectedk8s extension — not just new code. Since our dependency spec uses `ruff>=0.7.2` (a floor with no ceiling), CI installs the latest version, which now breaks.

## Fix
Cap ruff at `<0.16.0` in the linting extras. This restores CI to the behavior we had with 0.15.x while allowing patch updates within that range.

## Follow-up
A future PR can upgrade to 0.16.0+ by addressing the new rule violations or suppressing them in `pyproject.toml`.