### PR TITLE
Fix pre-onboarding diagnostic checks grading NotCompleted job as Pass

### DIFF
--- a/src/connectedk8s/azext_connectedk8s/_constants.py
+++ b/src/connectedk8s/azext_connectedk8s/_constants.py
@@ -493,7 +493,7 @@ SigningKey_CR_Snapshot = "signingkey_cr_snapshot.txt"
 
 # Connect Precheck Diagnoser constants
 Cluster_Diagnostic_Checks_Job_Registry_Path = (
-    "azurearck8s/helmchart/stable/clusterdiagnosticchecks:1.31.2"
+    "azurearck8s/helmchart/stable/clusterdiagnosticchecks:1.36.1"
 )
 Cluster_Diagnostic_Checks_Helm_Install_Failed_Fault_Type = (
     "Error while installing cluster diagnostic checks helm release"

--- a/src/connectedk8s/azext_connectedk8s/_precheckutils.py
+++ b/src/connectedk8s/azext_connectedk8s/_precheckutils.py
@@ -493,6 +493,13 @@ def fetch_diagnostic_checks_results(  # pylint: disable=too-many-return-statemen
             )
             return consts.Diagnostic_Check_Failed, storage_space_available
 
+        # If the job did not complete, partial results cannot be trusted -- treat as Incomplete.
+        # The container may have exited early, causing some checks to appear
+        # Passed/NotApplicable while later checks never actually executed.
+        if prediagnostic_job_execution_status == consts.Job_Status_Not_Completed:
+            send_prediagnostic_job_execution_error_telemetry()
+            return consts.Diagnostic_Check_Incomplete, storage_space_available
+
         # All checks passed or not applicable
         return consts.Diagnostic_Check_Passed, storage_space_available
 

--- a/src/connectedk8s/azext_connectedk8s/custom.py
+++ b/src/connectedk8s/azext_connectedk8s/custom.py
@@ -1670,7 +1670,9 @@ def connected_cluster_exists(
 
 
 def get_cloud_based_domain(cmd: CLICommand) -> str:
-    active_directory_array = str(cmd.cli_ctx.cloud.endpoints.active_directory).split(".")
+    active_directory_array = str(cmd.cli_ctx.cloud.endpoints.active_directory).split(
+        "."
+    )
     # default for public, mc, ff clouds
     cloud_based_domain = active_directory_array[2]
     # special cases for USSec/USNat clouds
@@ -4953,7 +4955,9 @@ def crd_cleanup_force_delete(
 ) -> None:
     print(f"Step: {utils.get_utctimestring()}: Deleting Arc CRDs")
 
-    active_directory_array = str(cmd.cli_ctx.cloud.endpoints.active_directory).split(".")
+    active_directory_array = str(cmd.cli_ctx.cloud.endpoints.active_directory).split(
+        "."
+    )
     # default for public, mc, ff clouds
     cloud_based_domain = active_directory_array[2]
     # special cases for USSec/USNat clouds

--- a/src/connectedk8s/azext_connectedk8s/custom.py
+++ b/src/connectedk8s/azext_connectedk8s/custom.py
@@ -1670,7 +1670,7 @@ def connected_cluster_exists(
 
 
 def get_cloud_based_domain(cmd: CLICommand) -> str:
-    active_directory_array = cmd.cli_ctx.cloud.endpoints.active_directory.split(".")
+    active_directory_array = str(cmd.cli_ctx.cloud.endpoints.active_directory).split(".")
     # default for public, mc, ff clouds
     cloud_based_domain = active_directory_array[2]
     # special cases for USSec/USNat clouds
@@ -4953,7 +4953,7 @@ def crd_cleanup_force_delete(
 ) -> None:
     print(f"Step: {utils.get_utctimestring()}: Deleting Arc CRDs")
 
-    active_directory_array = cmd.cli_ctx.cloud.endpoints.active_directory.split(".")
+    active_directory_array = str(cmd.cli_ctx.cloud.endpoints.active_directory).split(".")
     # default for public, mc, ff clouds
     cloud_based_domain = active_directory_array[2]
     # special cases for USSec/USNat clouds


### PR DESCRIPTION
## Summary

Three fixes for the pre-onboarding diagnostic check flow:

1. **Bug fix — `NotCompleted` job graded as `Passed`** when the container produces partial output
2. **Image bump — `clusterdiagnosticchecks` updated to `1.36.1`** (fixes failures on USSec/USNat; previous pin `1.31.2` doesn't run on newer node images)
3. **Mypy fix — `[no-any-return]` in two functions** that call `.split(".")` on an untyped `knack` attribute (pre-existing CI failure)

---

## Root Cause (fix 1)

When the diagnostics container exits early (`jobExecutionStatus=NotCompleted`), it may have already written partial output for checks that did run. The CLI parsed that output, found individual checks as `Passed`/`NotApplicable`, and graded the overall result as **Passed** — even though later checks never executed.

**Repro telemetry from bug report:**
```
jobExecutionStatus=NotCompleted; dnsCheck=Passed; outboundConnectivityCheck=Passed; entraCheck=NotApplicable; crdCheck=Passed
```

The `Job_Status_Not_Completed` guard existed only in the empty-log path. The non-empty partial-log path had no guard and fell through to `return Diagnostic_Check_Passed`.

---

## Changes

### `_precheckutils.py` (+7 lines)
Added guard in the **non-empty log path** of `fetch_diagnostic_checks_results`, after the `Failed` check and before `return Diagnostic_Check_Passed`:

```python
# If the job did not complete, partial results cannot be trusted -- treat as Incomplete.
# The container may have exited early, causing some checks to appear
# Passed/NotApplicable while later checks never actually executed.
if prediagnostic_job_execution_status == consts.Job_Status_Not_Completed:
    send_prediagnostic_job_execution_error_telemetry()
    return consts.Diagnostic_Check_Incomplete, storage_space_available
```

`Diagnostic_Check_Incomplete` propagates to `custom.py`, which raises `ValidationError` and halts onboarding.

### `_constants.py` (1 line)
Bumped `Cluster_Diagnostic_Checks_Job_Registry_Path` from `clusterdiagnosticchecks:1.31.2` → `1.36.1`. The `1.31.2` image does not run on USSec/USNat node images; `1.36.1` includes the AGC and sovereign cloud fixes.

### `custom.py` (2 lines, 2 sites)
Cast `cmd.cli_ctx.cloud.endpoints.active_directory` to `str` before `.split(".")` in two functions, fixes AZ CLI typecheck:
- `get_cloud_based_domain` (line 1673)
- `crd_cleanup_force_delete` (line 4956)

Since `knack` has no type stubs the attribute is `Any`, propagating `Any` through list indexing to any `return` — a `[no-any-return]` error under `mypy --strict`. The `str()` cast gives mypy a concrete `list[str]`. No behavioral change.

---